### PR TITLE
Make jump.js a11y option available in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ configureAnchors({offset: -60, scrollDuration: 200})
 | `offset`              | `0`              |
 | `scrollDuration`      | `400`            |
 | `keepLastAnchorHash`  | `false`          |
+| `a11y`                | `false`          |
 
 ### 3. Utilities
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-scrollable-anchor",
+  "name": "@daveobriencouk/react-scrollable-anchor",
   "version": "0.4.2",
   "description": "Provide smooth scrolling anchors in React.",
   "main": "lib/index.js",

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -7,6 +7,7 @@ const defaultConfig = {
   offset: 0,
   scrollDuration: 400,
   keepLastAnchorHash: false,
+  a11y: false,
 }
 
 class Manager {
@@ -85,6 +86,7 @@ class Manager {
       jump(element, {
         duration: this.config.scrollDuration,
         offset: this.config.offset,
+        a11y: this.config.a11y,
       })
     } else {
       // make sure that standard hash anchors don't break.
@@ -94,6 +96,7 @@ class Manager {
         jump(element, {
           duration: 0,
           offset: this.config.offset,
+          a11y: this.config.a11y,
         })
       }
     }


### PR DESCRIPTION
Hello.

I wanted to access the [a11y option](https://github.com/callmecavs/jump.js#a11y) in **jump.js** from within your react component. I've set it to false as default.

Could you take a look whenever you get some time, see if it's something you want to include?

Thanks

Dave