### PR TITLE
Switching PropTypes validation from core React package to 'prop-types'

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "homepage": "https://github.com/gabergg/react-scrollable-anchor",
   "dependencies": {
-    "jump.js": "1.0.1"
+    "jump.js": "1.0.1",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "^15.3.0",

--- a/src/ScrollableAnchor.js
+++ b/src/ScrollableAnchor.js
@@ -1,5 +1,6 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types';
 import Manager from './Manager'
 
 export default class ScrollableAnchor extends Component {


### PR DESCRIPTION
From v15.5.0 of React, a warning is displayed in the console if PropTypes are accessed from the React package directly. We now have to access PropTypes from the new separate 'prop-types' package. This stops the warning.

Details here: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html