### PR TITLE
Round getBoundingClientRect values

### DIFF
--- a/src/utils/scroll.js
+++ b/src/utils/scroll.js
@@ -7,8 +7,8 @@ export const getElementOffset = (element) => {
   const scrollTop = getScrollTop()
   const {top, bottom} = element.getBoundingClientRect()
   return {
-    top: top + scrollTop,
-    bottom: bottom + scrollTop
+    top: Math.floor(top + scrollTop),
+    bottom: Math.floor(bottom + scrollTop)
   }
 }
 


### PR DESCRIPTION
When using react-scrollable-anchors with sections that have sub-pixel heights the hash is always one section behind after the animation ends.
This is because browser API window.scrollTo() (in jump.js) and [scrollTop](https://github.com/gabergg/react-scrollable-anchor/blob/d41ebc98842a93b29be07cd759dee8862795e828/src/utils/scroll.js#L2) are whole pixel integers and [getBoundingClientRect()](https://github.com/gabergg/react-scrollable-anchor/blob/d41ebc98842a93b29be07cd759dee8862795e828/src/utils/scroll.js#L8) returns float values.
Rounding the getBoundingClientRect values solved the issue for me.
Thoughts?