### PR TITLE
Allow containers other than window to scroll

### DIFF
--- a/example/src/components/App.js
+++ b/example/src/components/App.js
@@ -3,6 +3,7 @@ import Example1 from './Example1'
 import Example2 from './Example2'
 import Example3 from './Example3'
 import Example4 from './Example4'
+import Example5 from './Example5'
 import ScrollableAnchor, { goToTop, goToAnchor, removeHash } from '../../../src'
 
 const examples = [
@@ -10,6 +11,7 @@ const examples = [
   {id: 'example2', label: 'Example 2', component: Example2},
   {id: 'example3', label: 'Example 3', component: Example3},
   {id: 'example4', label: 'Example 4', component: Example4},
+  {id: 'example5', label: 'Example 5', component: Example5},
 ]
 
 const styles = {

--- a/example/src/components/Example5.js
+++ b/example/src/components/Example5.js
@@ -1,0 +1,58 @@
+import React, { Component } from 'react'
+import ScrollableAnchor, { configureAnchors } from '../../../src'
+import Section from './Section'
+
+const sections = [
+  {id: 'section1', label: 'Section 1', backgroundColor: 'red'},
+  {id: 'section2', label: 'Section 2', backgroundColor: 'darkgray'},
+  {id: 'section3', label: 'Section 3', backgroundColor: 'green'},
+  {id: 'section4', label: 'Section 4', backgroundColor: 'brown'},
+  {id: 'section5', label: 'Section 5', backgroundColor: 'lightpink'}
+]
+
+const styles = {
+  offsetUp: {
+    marginTop: '-549px'
+  },
+  extraTall: {
+    height: '700px'
+  },
+  scrollingDiv: {
+    height: '50vh',
+    overflowY: 'scroll',
+    marginTop: '25vh',
+    width: '50%',
+    marginLeft: '25%',
+    position: 'relative'
+  }
+
+}
+
+export default class Example5 extends Component {
+
+  componentWillMount() {
+    configureAnchors({containerId: 'scrolling-div'})
+  }
+
+  renderSection = (section) => {
+    const props = {...section, sections, style: styles.extraTall}
+    return (
+      <div key={section.id}>
+        <ScrollableAnchor id={section.id}>
+          <Section {...props}/>
+        </ScrollableAnchor>
+      </div>
+    )
+  }
+
+  render() {
+    return (
+      <div>
+        { this.props.renderHeader(true, sections, true) }
+        <div id='scrolling-div' style={styles.scrollingDiv}>
+          { sections.map(this.renderSection) }
+        </div>
+      </div>
+    )
+  }
+}

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "homepage": "https://github.com/gabergg/react-scrollable-anchor",
   "dependencies": {
-    "jump.js": "1.0.2",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "zenscroll": "^4.0.2"
   },
   "peerDependencies": {
     "react": "^15.3.0 || ^16.0.0",

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -48,8 +48,7 @@ class Manager {
 
   goToTop = () => {
     if (getScrollTop() === 0) return
-    this.forcedHash = true
-    (container).scroll(0,0)
+    zenscroll.toY(0)
     removeHash()
   }
 
@@ -96,8 +95,10 @@ class Manager {
 
   goToSection = (id) => {
     let element = this.anchors[id]
+    let viewHeight = this.config.container.innerHeight || this.config.container.clientHeight
+    let offset = this.config.offset + viewHeight/2
     if (element) {
-      zenscroll.center(element, this.config.scrollDuration, this.config.offset)
+      zenscroll.center(element, this.config.scrollDuration, offset)
     } else {
       // make sure that standard hash anchors don't break.
       // simply jump to them.

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -24,8 +24,10 @@ class Manager {
     // if we have a containerId, find the scrolling container, else set it to window
     if (this.config.containerId) {
       this.config.container = document.getElementById(this.config.containerId)
+      this.config.scroller = zenscroll.createScroller(this.config.container, this.config.scrollDuration, this.config.offset)
     } else {
       this.config.container = window
+      this.config.scroller = zenscroll
     }
   }
 
@@ -47,8 +49,8 @@ class Manager {
   }
 
   goToTop = () => {
-    if (getScrollTop() === 0) return
-    zenscroll.toY(0)
+    if (getScrollTop(this.config.container) === 0) return
+    this.config.scroller.toY(0, this.config.scrollDuration)
     removeHash()
   }
 
@@ -75,7 +77,7 @@ class Manager {
 
   handleScroll = () => {
     const {offset, keepLastAnchorHash} = this.config
-    const bestAnchorId = getBestAnchorGivenScrollLocation(this.anchors, offset)
+    const bestAnchorId = getBestAnchorGivenScrollLocation(this.anchors, offset, this.config.container)
 
     if (bestAnchorId && getHash() !== bestAnchorId) {
       this.forcedHash = true
@@ -98,13 +100,13 @@ class Manager {
     let viewHeight = this.config.container.innerHeight || this.config.container.clientHeight
     let offset = this.config.offset + viewHeight/2
     if (element) {
-      zenscroll.center(element, this.config.scrollDuration, offset)
+      this.config.scroller.center(element, this.config.scrollDuration, offset)
     } else {
       // make sure that standard hash anchors don't break.
       // simply jump to them.
       element = document.getElementById(id)
       if (element) {
-        zenscroll.center(element, 0, this.config.offset)
+        this.config.scroller.center(element, 0, this.config.offset)
       }
     }
   }

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -3,29 +3,34 @@ import { debounce } from './utils/func'
 import { getBestAnchorGivenScrollLocation } from './utils/scroll'
 import { getHash, updateHash, removeHash } from './utils/hash'
 
+const defaultContainer = window;
+
 const defaultConfig = {
   offset: 0,
   scrollDuration: 400,
+  container: defaultContainer
 }
+
 
 class Manager {
   constructor() {
     this.anchors = {}
     this.forcedHash = false
     this.config = defaultConfig
+    this.container = this.config.container;
 
     this.scrollHandler = debounce(this.handleScroll, 250)
     this.forceHashUpdate = debounce(this.handleHashChange, 1)
   }
 
   addListeners = () => {
-    window.addEventListener('scroll', this.scrollHandler, false)
-    window.addEventListener('hashchange', this.handleHashChange)
+    this.config.container.addEventListener('scroll', this.scrollHandler, false)
+    this.config.container.addEventListener('hashchange', this.handleHashChange)
   }
 
   removeListeners = () => {
-    window.removeEventListener('scroll', this.scrollHandler, false)
-    window.removeEventListener('hashchange', this.handleHashChange)
+    this.config.container.removeEventListener('scroll', this.scrollHandler, false)
+    this.config.container.removeEventListener('hashchange', this.handleHashChange)
   }
 
   configure = (config) => {
@@ -33,11 +38,12 @@ class Manager {
       ...defaultConfig,
       ...config,
     }
+    this.config.container = this.config.container;
   }
 
   goToTop = () => {
     this.forcedHash = true
-    window.scroll(0,0)
+    (container).scroll(0,0)
     removeHash()
   }
 

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -50,8 +50,8 @@ class Manager {
 
   goToTop = () => {
     if (getScrollTop(this.config.container) === 0) return
+    this.forcedHash = true
     this.config.scroller.toY(0, this.config.scrollDuration)
-    removeHash()
   }
 
   addAnchor = (id, component) => {

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -50,7 +50,6 @@ class Manager {
 
   goToTop = () => {
     if (getScrollTop(this.config.container) === 0) return
-    this.forcedHash = true
     this.config.scroller.toY(0, this.config.scrollDuration)
   }
 

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -3,13 +3,10 @@ import { debounce } from './utils/func'
 import { getBestAnchorGivenScrollLocation, getScrollTop } from './utils/scroll'
 import { getHash, updateHash, removeHash } from './utils/hash'
 
-const defaultContainer = window;
-
 const defaultConfig = {
   offset: 0,
   scrollDuration: 400,
-  container: defaultContainer,
-  keepLastAnchorHash: false,
+  keepLastAnchorHash: false
 }
 
 
@@ -18,10 +15,18 @@ class Manager {
     this.anchors = {}
     this.forcedHash = false
     this.config = defaultConfig
-    this.container = this.config.container;
 
     this.scrollHandler = debounce(this.handleScroll, 100)
     this.forceHashUpdate = debounce(this.handleHashChange, 1)
+  }
+
+  setContainer = () => {
+    // if we have a containerId, find the scrolling container, else set it to window
+    if (this.config.containerId) {
+      this.config.container = document.getElementById(this.config.containerId)
+    } else {
+      this.config.container = window
+    }
   }
 
   addListeners = () => {
@@ -37,9 +42,8 @@ class Manager {
   configure = (config) => {
     this.config = {
       ...defaultConfig,
-      ...config,
+      ...config
     }
-    this.config.container = this.config.container;
   }
 
   goToTop = () => {
@@ -50,6 +54,10 @@ class Manager {
   }
 
   addAnchor = (id, component) => {
+    // if container is not set, set container
+    if (!this.config.container) {
+      this.setContainer()
+    }
     // if this is the first anchor, set up listeners
     if (Object.keys(this.anchors).length === 0) {
       this.addListeners()

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -1,4 +1,4 @@
-import jump from 'jump.js'
+import zenscroll from 'zenscroll'
 import { debounce } from './utils/func'
 import { getBestAnchorGivenScrollLocation, getScrollTop } from './utils/scroll'
 import { getHash, updateHash, removeHash } from './utils/hash'
@@ -97,19 +97,13 @@ class Manager {
   goToSection = (id) => {
     let element = this.anchors[id]
     if (element) {
-      jump(element, {
-        duration: this.config.scrollDuration,
-        offset: this.config.offset,
-      })
+      zenscroll.center(element, this.config.scrollDuration, this.config.offset)
     } else {
       // make sure that standard hash anchors don't break.
       // simply jump to them.
       element = document.getElementById(id)
       if (element) {
-        jump(element, {
-          duration: 0,
-          offset: this.config.offset,
-        })
+        zenscroll.center(element, 0, this.config.offset)
       }
     }
   }

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -33,12 +33,12 @@ class Manager {
 
   addListeners = () => {
     this.config.container.addEventListener('scroll', this.scrollHandler, false)
-    this.config.container.addEventListener('hashchange', this.handleHashChange)
+    window.addEventListener('hashchange', this.handleHashChange)
   }
 
   removeListeners = () => {
     this.config.container.removeEventListener('scroll', this.scrollHandler, false)
-    this.config.container.removeEventListener('hashchange', this.handleHashChange)
+    window.removeEventListener('hashchange', this.handleHashChange)
   }
 
   configure = (config) => {


### PR DESCRIPTION
Addresses issue [4](https://github.com/gabergg/react-scrollable-anchor/issues/4) by building upon [pull 37](https://github.com/gabergg/react-scrollable-anchor/pull/37)

See example 5 [here](https://dbramwell.github.io/react-scrollable-anchor/)

Edit:
I've now pushed a release of this into a branch on my github fork. Hopefully this will be merged soon, but for now the new feature can be used by adding the following to the dependencies in your package.json:
`"react-scrollable-anchor": "github:dbramwell/react-scrollable-anchor#release"`