### PR TITLE
Adds autoUpdateAnchorHash option, default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ configureAnchors({offset: -60, scrollDuration: 200})
 
 ##### Options:
 
-| option                | default          |
-| --------------------  | ---------------- |
-| `offset`              | `0`              |
-| `scrollDuration`      | `400`            |
-| `keepLastAnchorHash`  | `false`          |
+| option                 | default          |
+| ---------------------- | ---------------- |
+| `offset`               | `0`              |
+| `scrollDuration`       | `400`            |
+| `keepLastAnchorHash`   | `false`          |
+| `autoUpdateAnchorHash` | `true`           |
 
 ### 3. Utilities
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fernando-msj/react-scrollable-anchor",
+  "name": "react-scrollable-anchor",
   "version": "0.6.2",
   "description": "Provide smooth scrolling anchors in React.",
   "main": "lib/index.js",
@@ -36,12 +36,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/fernando-msj/react-scrollable-anchor.git"
+    "url": "https://github.com/gabergg/react-scrollable-anchor.git"
   },
   "bugs": {
     "url": "https://github.com/gabergg/react-scrollable-anchor/issues"
   },
-  "homepage": "https://github.com/fernando-msj/react-scrollable-anchor",
+  "homepage": "https://github.com/gabergg/react-scrollable-anchor",
   "dependencies": {
     "jump.js": "1.0.2",
     "prop-types": "^15.5.10"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-scrollable-anchor",
+  "name": "@fernando-msj/react-scrollable-anchor",
   "version": "0.6.2",
   "description": "Provide smooth scrolling anchors in React.",
   "main": "lib/index.js",
@@ -36,12 +36,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gabergg/react-scrollable-anchor.git"
+    "url": "https://github.com/fernando-msj/react-scrollable-anchor.git"
   },
   "bugs": {
     "url": "https://github.com/gabergg/react-scrollable-anchor/issues"
   },
-  "homepage": "https://github.com/gabergg/react-scrollable-anchor",
+  "homepage": "https://github.com/fernando-msj/react-scrollable-anchor",
   "dependencies": {
     "jump.js": "1.0.2",
     "prop-types": "^15.5.10"

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -7,6 +7,7 @@ const defaultConfig = {
   offset: 0,
   scrollDuration: 400,
   keepLastAnchorHash: false,
+  autoUpdateAnchorHash: true,
 }
 
 class Manager {
@@ -60,10 +61,13 @@ class Manager {
   }
 
   handleScroll = () => {
-    const {offset, keepLastAnchorHash} = this.config
-    const bestAnchorId = getBestAnchorGivenScrollLocation(this.anchors, offset)
+    const {offset, keepLastAnchorHash, autoUpdateAnchorHash} = this.config
+    let bestAnchorId;
 
-    if (bestAnchorId && getHash() !== bestAnchorId) {
+    if (autoUpdateAnchorHash)
+      bestAnchorId = getBestAnchorGivenScrollLocation(this.anchors, offset)
+
+    if (autoUpdateAnchorHash && bestAnchorId && getHash() !== bestAnchorId) {
       this.forcedHash = true
       updateHash(bestAnchorId, false)
     } else if (!bestAnchorId && !keepLastAnchorHash) {


### PR DESCRIPTION
I have the need to configure the library to not automatically update the URL hash during scroll events, the library currently doesn't support this. This PR adds the `autoUpdateAnchorHash` option, so you can configure it when calling the `configureAnchors` function.

While this PR isn't merged our team will be using `@fernando-msj/react-scrollable-anchor`.